### PR TITLE
remove logMessageReceived event handler

### DIFF
--- a/Assets/Plugins/ExternalLogger.cs
+++ b/Assets/Plugins/ExternalLogger.cs
@@ -55,7 +55,6 @@ using UnityEngine.Experimental.Networking;
         private void OnEnable()
         {
             // Debug.LogFormat("ExternalLogger -> OnEnable to {0}", filePath);
-            Application.logMessageReceived += MessageReceived;
             Application.logMessageReceivedThreaded += MessageReceived;
             StartCoroutine("SendLogs");
         }
@@ -122,7 +121,6 @@ using UnityEngine.Experimental.Networking;
 
         private void OnDisable()
         {
-            Application.logMessageReceived -= MessageReceived;
             Application.logMessageReceivedThreaded -= MessageReceived;
             StopCoroutine("SendLogs");
         }


### PR DESCRIPTION
https://docs.unity3d.com/ScriptReference/Application-logMessageReceivedThreaded.html

"Note that it is not necessary to subscribe to both Application.logMessageReceived and Application.logMessageReceivedThreaded. The multi-threaded variant will also be called for messages on the main thread."